### PR TITLE
Credit card number is not import for accessibility service for securi…

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -17,6 +17,7 @@
             android:layout_height="wrap_content"
             android:hint="@string/hint_credit_cart_number"
             android:inputType="number"
+            android:importantForAccessibility="no"
             app:met_mask="#### #### #### ####"/>
 
     </android.support.design.widget.TextInputLayout>


### PR DESCRIPTION
For security reasons, this field should be set to be not important for accessibility. Otherwise it can be captured by malicious apps that are using the accessibility service.