### PR TITLE
Update MaskResult.kt

### DIFF
--- a/library/src/main/java/com/santalu/maskara/MaskResult.kt
+++ b/library/src/main/java/com/santalu/maskara/MaskResult.kt
@@ -23,7 +23,10 @@ internal fun MaskResult.apply(text: Editable) {
     text.filters = emptyArray()
 
     text.replace(0, text.length, masked)
-    Selection.setSelection(text, selection)
+    
+    // The selection could be higher than the length of the text if the EditText contains a filter then it'll lead it to crash.
+    val filteredSelection = min(selection, text?.length ?: 0)
+    Selection.setSelection(text, filteredSelection)
 
     // resume filters
     text.filters = filters


### PR DESCRIPTION
Fixed the selection that was leading to crash if the selection was higher than the length of the text.
Fixes #27 